### PR TITLE
fix: handle get app errors on get firebase helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ yarn build
 
 ## Extras
 
-Due to an [issue with volar](https://github.com/vuejs/language-tools/issues/5018#issuecomment-2495098549), typescript version is fixed at @5.6.3
-
 Firebase requires 2 keys, the private one from recaptcha, and the site key from recaptcha enterprise. The former one is passed from the config file.
 
 For app check create the key from Recaptcha v3 console instead of enterprise to avoid issues with legacy keys validation. The debug token allows bypassing the validation on dev environments

--- a/src/runtime/functions/utils/firebase.ts
+++ b/src/runtime/functions/utils/firebase.ts
@@ -1,4 +1,4 @@
-import { getApp, getApps, initializeApp, type AppOptions } from "firebase-admin/app";
+import { getApp, getApps, initializeApp, type App, type AppOptions } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
@@ -7,7 +7,15 @@ export function getFirebase(at = "Unknown", appOptions?: AppOptions) {
 	if (import.meta.client) throw new Error("This function is only available in server context");
 
 	try {
-		const firebaseApp = getApps().length ? getApp() : initializeApp(appOptions);
+		let firebaseApp: App;
+
+		try {
+			// getApp can trigger errors if app is not initialized
+			firebaseApp = getApps().length ? getApp() : initializeApp(appOptions);
+		} catch (err: any) {
+			firebaseApp = initializeApp(appOptions);
+		}
+
 		const firebaseFirestore = getFirestore(firebaseApp);
 		const firebaseAuth = getAuth(firebaseApp);
 		const firebaseStorage = getStorage();


### PR DESCRIPTION
Cloud build was throwing: FirebaseAppError: The default Firebase app does not exist. Make sure you call initializeApp() before using any of the Firebase services.