### PR TITLE
Remove csurf module

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ F_CLIENT_EMAIL=""
 # App check, site key, public
 RECAPTCHA_ENTERPRISE_SITE_KEY=
 
-# CSRF protection (32 bytes)
-# By default csurf uses `crypto.randomBytes(22).toString("base64")`
-CSURF_SECRET=
-
 # Project
 ORIGIN=
 COUNTRIES_API=

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.0.3",
     "lodash-es": "^4.17.21",
-    "nuxt-csurf": "^1.6.5",
     "pinia": "^3.0.2",
     "vue-router-better-scroller": "^0.0.0"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,12 +11,7 @@ import {
 
 import type { FirebaseNuxtModuleOptions } from "./types";
 import { locale } from "./runtime/client/utils/locale";
-import {
-	debugNuxt,
-	publicRuntimeConfig,
-	port,
-	csurfSecret,
-} from "./runtime/server/utils/environment";
+import { debugNuxt, publicRuntimeConfig, port } from "./runtime/server/utils/environment";
 
 /**
  * Nuxt module for @open-xamu-co/firebase-nuxt
@@ -174,13 +169,6 @@ export default defineNuxtModule<FirebaseNuxtModuleOptions>({
 		const runtimePath = resolve("./runtime");
 
 		return {
-			"nuxt-csurf": {
-				version: ">=1.6.5",
-				defaults: {
-					addCsrfTokenToEventCtx: true, // Run server side
-					encryptSecret: csurfSecret.value() || undefined,
-				},
-			},
 			"@open-xamu-co/ui-nuxt": {
 				version: ">=4.0.0-next.4",
 				defaults: {

--- a/src/runtime/composables/useQuery.ts
+++ b/src/runtime/composables/useQuery.ts
@@ -8,7 +8,7 @@ import { useRequestHeaders, useNuxtApp, useRuntimeConfig, useSessionStore } from
  * @param baseOptions
  * @returns
  */
-async function getQueryOptions<R extends NitroFetchRequest = NitroFetchRequest>(
+export async function getQueryOptions<R extends NitroFetchRequest = NitroFetchRequest>(
 	baseOptions?: NitroFetchOptions<R>
 ): Promise<NitroFetchOptions<R>> {
 	const SESSION = useSessionStore();
@@ -35,19 +35,6 @@ async function getQueryOptions<R extends NitroFetchRequest = NitroFetchRequest>(
 	}
 
 	return { credentials: "same-origin", ...options, query, headers };
-}
-
-/**
- * Fetch wrapper with csrf token
- */
-export async function useCsrfQuery<T, R extends NitroFetchRequest = NitroFetchRequest>(
-	url: Extract<R, string>,
-	baseOptions?: NitroFetchOptions<R>
-) {
-	const { $csrfFetch } = useNuxtApp();
-	const { responseType, ...options } = await getQueryOptions(baseOptions);
-
-	return $csrfFetch<T>(url, options);
 }
 
 /**

--- a/src/runtime/server/utils/cache.ts
+++ b/src/runtime/server/utils/cache.ts
@@ -1,4 +1,9 @@
-import { type EventHandlerRequest, type EventHandlerResponse, defineEventHandler } from "h3";
+import {
+	type EventHandlerRequest,
+	type EventHandlerResponse,
+	defineEventHandler,
+	setResponseHeaders,
+} from "h3";
 import { defineCachedEventHandler } from "nitropack/runtime";
 
 import { debugNitro } from "../utils/environment";
@@ -51,6 +56,10 @@ export const defineConditionallyCachedEventHandler = <
 	return defineEventHandler<T>(async (event: CachedH3Event<T>) => {
 		// Bypass cache for admin purposes
 		if (sudo(event.context) || debugNitro.value()) return handler(event);
+
+		setResponseHeaders(event, {
+			"Cache-Control": "max-age=30, must-revalidate",
+		});
 
 		return cachedHandler(event);
 	});

--- a/src/runtime/server/utils/environment.ts
+++ b/src/runtime/server/utils/environment.ts
@@ -81,12 +81,6 @@ export const clientEmail = defineString("F_CLIENT_EMAIL");
 export const recaptchaEnterpriseKey = defineString("RECAPTCHA_ENTERPRISE_SITE_KEY");
 
 /**
- * CSurf encryption secret
- * Required for CSRF protected routes
- */
-export const csurfSecret = defineString("CSURF_SECRET");
-
-/**
  * Firebase client data
  */
 export const firebaseConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,7 +2942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/kit@npm:3.20.2, @nuxt/kit@npm:^3.13.2, @nuxt/kit@npm:^3.15.4, @nuxt/kit@npm:^3.18.0, @nuxt/kit@npm:^3.20.2":
+"@nuxt/kit@npm:3.20.2, @nuxt/kit@npm:^3.15.4, @nuxt/kit@npm:^3.18.0, @nuxt/kit@npm:^3.20.2":
   version: 3.20.2
   resolution: "@nuxt/kit@npm:3.20.2"
   dependencies:
@@ -3405,7 +3405,6 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     nuxi: "npm:^3.31.2"
     nuxt: "npm:^3.20.2"
-    nuxt-csurf: "npm:^1.6.5"
     pinia: "npm:^3.0.2"
     postcss: "npm:^8.5.6"
     postcss-cli: "npm:^11.0.1"
@@ -13845,17 +13844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nuxt-csurf@npm:^1.6.5":
-  version: 1.6.5
-  resolution: "nuxt-csurf@npm:1.6.5"
-  dependencies:
-    "@nuxt/kit": "npm:^3.13.2"
-    defu: "npm:^6.1.4"
-    uncsrf: "npm:^1.2.0"
-  checksum: 10c0/104b2c5ff89af3615c6f6bd2c4adc05531f20271104b331d2acbd73ee9caf6ea8b066d98d470ffd829ee21850619bf5815c87559e8e8f1723f5eeaf6ca738822
-  languageName: node
-  linkType: hard
-
 "nuxt@npm:^3.20.2":
   version: 3.20.2
   resolution: "nuxt@npm:3.20.2"
@@ -19141,13 +19129,6 @@ postcss-precision@vis97c/postcss-precision:
   version: 0.1.3
   resolution: "uncrypto@npm:0.1.3"
   checksum: 10c0/74a29afefd76d5b77bedc983559ceb33f5bbc8dada84ff33755d1e3355da55a4e03a10e7ce717918c436b4dfafde1782e799ebaf2aadd775612b49f7b5b2998e
-  languageName: node
-  linkType: hard
-
-"uncsrf@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "uncsrf@npm:1.2.0"
-  checksum: 10c0/608a5fe8a37bd2e06aae3c1a969cdfa4e67d9ced384b0d4405b2eabe5f21ce0e7607f937b866797bf397e742d94f2239c5164d01ac2a2f0d5f1249370bcd4122
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Due to [security concerns](https://github.com/nuxt/modules/issues/1384) I'm removing this module & related feature. Projects extending module should implement their own security layer.

getQueryOptions composable is now exposed for easy $fetch wrapping with auth defaults.

